### PR TITLE
Update apps.json to new AltSource API

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -11,6 +11,15 @@ permalink: /
       "name": "SideStore",
       "bundleIdentifier": "com.SideStore.SideStore",
       "developerName": "SideStore Team",
+      "versions": [
+        {
+          "version": "0.1.1",
+          "date": "2022-011-22T12:00:00-05:00",
+          "localizedDescription": "Welcome to the next generation of sideloading! This update fixes and adds the following:\n\n - Officially adds ability to pair via a mobiledevicepairing and a plist file.\n\n - Changes patreon page. fixes GroupID staging issues.\n\n - Fixes refreshing SideStore creating a second app or fails refreshing.",
+          "downloadURL": "https://github.com/SideStore/SideStore/releases/download/0.1.1/SideStore.ipa",
+          "size": 5465976
+        }
+      ],
       "version": "0.1.1",
       "versionDate": "2022-011-22T12:00:00-05:00",
       "versionDescription": "Welcome to the next generation of sideloading! This update fixes and adds the following:\n\n - Officially adds ability to pair via a mobiledevicepairing and a plist file.\n\n - Changes patreon page. fixes GroupID staging issues.\n\n - Fixes refreshing SideStore creating a second app or fails refreshing.",


### PR DESCRIPTION
At the moment, I've left the original API for keeping app details in there to support AltStore Beta versions below 1.6, but the properties can be removed at a later date. 

For now, I would also recommend creating a new "version" anytime there is a new release as well to maintain old versions of the app in perpetuity. I haven't tested with the latest AltStore Beta, but there was an oddity where AltStore v1.6b3 would only show the first version in the list regardless of which version was higher, so keep this in mind.