### PR TITLE
Remove old api changes

### DIFF
--- a/_includes/source.json
+++ b/_includes/source.json
@@ -79,7 +79,5 @@
       "notify": false
     }
   ],
-  "userInfo": {
-    "patreonAccessToken": "uqoDoTxH8dY1ImE8tK76wxrzKk67gjyjBAcK8sD3RLU"
-  }
+  "userInfo": {}
 }

--- a/_includes/source.json
+++ b/_includes/source.json
@@ -16,14 +16,9 @@
           "size": 5465976
         }
       ],
-      "version": "0.1.1",
-      "versionDate": "2022-011-22T12:00:00-05:00",
-      "versionDescription": "Welcome to the next generation of sideloading! This update fixes and adds the following:\n\n - Officially adds ability to pair via a mobiledevicepairing and a plist file.\n\n - Changes patreon page. fixes GroupID staging issues.\n\n - Fixes refreshing SideStore creating a second app or fails refreshing.",
-      "downloadURL": "https://github.com/SideStore/SideStore/releases/download/0.1.1/SideStore.ipa",
       "localizedDescription": "SideStore is an alternative app store for non-jailbroken devices. \n\nSideStore allows you to sideload other .ipa files and apps from the Files app or via the SideStore Library",
       "iconURL": "https://apps.sidestore.io/apps/sidestore/v0.1.1/icon.png",
       "tintColor": "A405FA",
-      "size": 5465976,
       "screenshotURLs": [
         "https://apps.sidestore.io/apps/sidestore/v0.1.1/browse-dark.png",
         "https://apps.sidestore.io/apps/sidestore/v0.1.1/apps-dark.png",


### PR DESCRIPTION
These lines removed are only there to support older Beta AltStore versions, but we don’t care about those devices so they should be removed